### PR TITLE
:heavy_plus_sign: Add xarray-datatree

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - jupyter-book=0.13.1
   - jupyterlab=3.5.0
   - python=3.9
+  - xarray-datatree=0.0.9


### PR DESCRIPTION
Implementation of a tree-like hierarchical data structure for xarray! Repository at https://github.com/xarray-contrib/datatree/tree/v0.0.9

Enables reading of nested ICESat-2 HDF5 files into an `xarray`-like structure, following the example at https://discourse.pangeo.io/t/reader-load-issues-with-atl06/2761/2