### PR TITLE
:heavy_plus_sign: Add jupytext configuration to render py scripts

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -30,6 +30,8 @@ repository:
   path_to_book: book  # Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
 
+only_build_toc_files: true
+
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
@@ -45,3 +47,8 @@ sphinx:
   config:
     bibtex_reference_style: author_year
     html_show_copyright: false
+    # https://jupyterbook.org/en/stable/file-types/jupytext.html
+    nb_custom_formats:
+      .py:
+        - jupytext.reads
+        - fmt: py:percent

--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - icepyx=0.6.4
   - jupyter-book=0.13.1
   - jupyterlab=3.5.0
+  - jupytext=1.14.0
   - python=3.9
   - xarray-datatree=0.0.9


### PR DESCRIPTION
To keep the git repository small and make git diffs easier, using [`jupytext`](https://github.com/mwouts/jupytext/tree/v1.14.0)! Specifically, this enables the tutorials to be written as plain-text `*.py` scripts instead of less human-readable JSON `*.ipynb` notebooks.

Once `jupytext` is installed, the `*.py` scripts can be opened in JupyterLab by right-clicking on the `*.py` file and selecting 'Open with -> Jupytext Notebook'.

![how to open .py file with jupytext, screenshot.](https://user-images.githubusercontent.com/23487320/202779015-dd99f830-b863-40ea-8d3b-52d09b7e8ee9.png)

References:
- https://jupyterbook.org/en/stable/file-types/jupytext.html
- Similar to https://github.com/ICESAT-2HackWeek/website2022/pull/40